### PR TITLE
Add mount functionality and split fraken-x build.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+	"name": "OpenRelik-devcontainer",
+	"image": "mcr.microsoft.com/devcontainers/base:noble",
+	"runArgs": [
+		"--privileged",
+		"-v",
+		"/dev:/dev"
+	],
+	"features": {
+    "ghcr.io/devcontainers-extra/features/poetry:2": {}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.python",
+				"ms-python.debugpy",
+				"charliermarsh.ruff"
+			]
+		}
+	}
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+	// Configure tool-specific properties.
+	// "customizations": {},
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,6 @@ RUN poetry install && rm -rf $POETRY_CACHE_DIR
 ENV VIRTUAL_ENV=/app/.venv PATH="/openrelik/.venv/bin:$PATH"
 
 COPY --from=ghcr.io/openrelik/fraken-x /app/fraken-x /bin/fraken
-# COPY --from=ghcr.io/openrelik/fraken-x /app/fraken-x /bin/fraken
 
 # Default command if not run from docker-compose (and command being overidden)
 CMD ["celery", "--app=src.tasks", "worker", "--task-events", "--concurrency=4", "--loglevel=INFO"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,3 @@
-FROM rust:alpine AS fraken-builder
-
-WORKDIR /app
-
-RUN apk add --no-cache musl-dev
-
-COPY fraken-x/ .
-
-RUN cargo build --release
-
 # Use the official Docker Hub Ubuntu base image
 FROM ubuntu:24.04 AS openrelik-builder
 
@@ -18,7 +8,11 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
 # Install poetry and any other dependency that your worker needs.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-poetry git \
-    # Add your dependencies here
+    # Mount dependencies
+    sudo \
+    fdisk \
+    qemu-utils \
+    ntfs-3g \
     && rm -rf /var/lib/apt/lists/*
 
 # Configure poetry
@@ -29,9 +23,9 @@ ENV POETRY_NO_INTERACTION=1 \
 
 # Configure debugging
 ARG OPENRELIK_PYDEBUG
-ENV OPENRELIK_PYDEBUG ${OPENRELIK_PYDEBUG:-0}
+ENV OPENRELIK_PYDEBUG=${OPENRELIK_PYDEBUG:-0}
 ARG OPENRELIK_PYDEBUG_PORT
-ENV OPENRELIK_PYDEBUG_PORT ${OPENRELIK_PYDEBUG_PORT:-5678}
+ENV OPENRELIK_PYDEBUG_PORT=${OPENRELIK_PYDEBUG_PORT:-5678}
 
 # Set working directory
 WORKDIR /openrelik
@@ -47,7 +41,8 @@ COPY . ./
 RUN poetry install && rm -rf $POETRY_CACHE_DIR
 ENV VIRTUAL_ENV=/app/.venv PATH="/openrelik/.venv/bin:$PATH"
 
-COPY --from=fraken-builder /app/target/release/fraken-x /bin/fraken
+COPY --from=ghcr.io/openrelik/fraken-x /app/fraken-x /bin/fraken
+# COPY --from=ghcr.io/openrelik/fraken-x /app/fraken-x /bin/fraken
 
 # Default command if not run from docker-compose (and command being overidden)
 CMD ["celery", "--app=src.tasks", "worker", "--task-events", "--concurrency=4", "--loglevel=INFO"]

--- a/Dockerfile.fraken
+++ b/Dockerfile.fraken
@@ -1,0 +1,16 @@
+FROM rust:alpine AS fraken-builder
+
+WORKDIR /app
+
+RUN apk add --no-cache musl-dev
+
+COPY fraken-x/ .
+
+RUN cargo build --release
+
+# Runtime stage
+FROM alpine:latest
+WORKDIR /app
+COPY --from=fraken-builder /app/target/release/fraken-x .
+# Specify the entrypoint to run your app
+ENTRYPOINT ["/app/fraken-x"]

--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ openrelik-worker-yara:
   command: "celery --app=src.app worker --task-events --concurrency=4 --loglevel=INFO -Q openrelik-worker-yara"
 ```
 
+## Loading Yara rules
+The worker can be loaded with yara rules in 2 different ways.
+1. Through the text input fiels shown in the UI
+2. Through the folder path input field shown in the UI
+
+The second option can be used to bootstrap persistent default rules. As shown above the shared volume is mapped into the container as `/usr/share/openrelik/data`. You can create a subfolder called `yara` there and bootstrap it with e.g. below ruleset from [Florian Roth](https://github.com/Neo23x0). 
+```
+mkdir -p ./data/yara
+cd ./data/yara
+git clone --depth 1 https://github.com/Neo23x0/signature-base.git
+```
+
+When running the worker you set the folder path to `/usr/share/openrelik/data/yara/` and it will use the rules.
 
 ## Building and running fraken-x Docker image
 The fraken-x source and container is build separately to keep the openrelik-worker-yara build independent and fast. The image is available at `ghcr.io/openrelik/fraken-x` and can be used standalone.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This worker scans input files or folders with Yara rules. It sources the rules f
 
 OpenRelik yara worker can be installed by using the pre-build Docker image.
 
-**Note on Privileges:** This worker requires `privileged` mode capabilities and the `/dev/` volume mapped to perform necessary mounting operations (e.g., mounting disk images). Be aware of the security implications of granting these privileges.
+**Note on Privileges:** If you would like this worker to support mounting disk images this worker requires `privileged` mode capabilities and the `/dev/` volume mapped to perform necessary mounting operations (e.g., mounting disk images). Be aware of the security implications of granting these privileges.
 
 ### Using Pre-built Docker Image
 
@@ -18,7 +18,6 @@ Update the `docker-compose.yml` to include `openrelik-worker-yara`.
 openrelik-worker-yara:
   container_name: openrelik-worker-yara
   image: ghcr.io/openrelik/openrelik-worker-yara:${OPENRELIK_WORKER_YARA_VERSION}
-  platform: linux/amd64
   privileged: true
   restart: always
   environment:
@@ -30,17 +29,12 @@ openrelik-worker-yara:
 ```
 
 
-## Building, pushing and running fraken-x Docker image
-The fraken-x source and container is build seperatly to keep the openrelik-worker-yara build independent and fast. The image is available at `ghcr.io/openrelik/fraken-x`
+## Building and running fraken-x Docker image
+The fraken-x source and container is build separately to keep the openrelik-worker-yara build independent and fast. The image is available at `ghcr.io/openrelik/fraken-x` and can be used standalone.
 
 Build
 ```
 $ docker build -t ghcr.io/openrelik/fraken-x -f Dockerfile.fraken .
-```
-
-Push
-```
-$ docker push ghcr.io/openrelik/fraken-x
 ```
 
 Run

--- a/README.md
+++ b/README.md
@@ -2,7 +2,61 @@
 
 ## Overview
 
-This worker scans input files with Yara rules.
+This worker scans input files or folders with Yara rules. It sources the rules from a given directory. It supports disk images that will be mounted.
 
-It sources the rules from a given directory.
+## Installation
 
+OpenRelik yara worker can be installed by using the pre-build Docker image.
+
+**Note on Privileges:** This worker requires `privileged` mode capabilities and the `/dev/` volume mapped to perform necessary mounting operations (e.g., mounting disk images). Be aware of the security implications of granting these privileges.
+
+### Using Pre-built Docker Image
+
+Update the `docker-compose.yml` to include `openrelik-worker-yara`.
+
+```yaml
+openrelik-worker-yara:
+  container_name: openrelik-worker-yara
+  image: ghcr.io/openrelik/openrelik-worker-yara:${OPENRELIK_WORKER_YARA_VERSION}
+  platform: linux/amd64
+  privileged: true
+  restart: always
+  environment:
+    - REDIS_URL=redis://openrelik-redis:6379
+  volumes:
+    - ./data:/usr/share/openrelik/data
+    - /dev:/dev
+  command: "celery --app=src.app worker --task-events --concurrency=4 --loglevel=INFO -Q openrelik-worker-yara"
+```
+
+
+## Building, pushing and running fraken-x Docker image
+The fraken-x source and container is build seperatly to keep the openrelik-worker-yara build independent and fast. The image is available at `ghcr.io/openrelik/fraken-x`
+
+Build
+```
+$ docker build -t ghcr.io/openrelik/fraken-x -f Dockerfile.fraken .
+```
+
+Push
+```
+$ docker push ghcr.io/openrelik/fraken-x
+```
+
+Run
+```
+$ docker run -ti ghcr.io/openrelik/fraken-x fraken-x --help
+Usage: fraken-x [OPTIONS] <--folder <FOLDER>|--testrules> <RULES>
+
+Arguments:
+  <RULES>  Specify a particular path to a file or folder containing the Yara rules to use
+
+Options:
+  -f, --folder <FOLDER>      Specify a particular folder to be scanned
+      --testrules            Test the rules for syntax validity and then exit
+      --magic <MAGIC>        A path under the rules path that contains File Magics [default: misc/file-type-signatures.txt]
+      --minscore <MINSCORE>  Only rules with scores greater than this will be output [default: 40]
+      --maxsize <MAXSIZE>    Only files less than this size will be scanned [default: 1073741824]
+  -h, --help                 Print help
+
+```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This worker scans input files or folders with Yara rules. It sources the rules f
 
 ## Installation
 
-OpenRelik yara worker can be installed by using the pre-build Docker image.
+OpenRelik yara worker can be installed by using the pre-built Docker image.
 
 **Note on Privileges:** If you would like this worker to support mounting disk images this worker requires `privileged` mode capabilities and the `/dev/` volume mapped to perform necessary mounting operations (e.g., mounting disk images). Be aware of the security implications of granting these privileges.
 
@@ -43,7 +43,7 @@ git clone --depth 1 https://github.com/Neo23x0/signature-base.git
 When running the worker you set the folder path to `/usr/share/openrelik/data/yara/` and it will use the rules.
 
 ## Building and running fraken-x Docker image
-The fraken-x source and container is build separately to keep the openrelik-worker-yara build independent and fast. The image is available at `ghcr.io/openrelik/fraken-x` and can be used standalone.
+The fraken-x source and container is built separately to keep the openrelik-worker-yara build independent and fast. The image is available at `ghcr.io/openrelik/fraken-x` and can be used standalone.
 
 Build
 ```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![codecov](https://codecov.io/gh/openrelik/openrelik-worker-yara/graph/badge.svg?token=IjJh9h02SS)](https://codecov.io/gh/openrelik/openrelik-worker-yara)
+
 # Yara scanner OpenRelik worker
 
 ## Overview

--- a/poetry.lock
+++ b/poetry.lock
@@ -263,38 +263,38 @@ toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
 name = "debugpy"
-version = "1.8.9"
+version = "1.8.14"
 description = "An implementation of the Debug Adapter Protocol for Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "debugpy-1.8.9-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:cfe1e6c6ad7178265f74981edf1154ffce97b69005212fbc90ca22ddfe3d017e"},
-    {file = "debugpy-1.8.9-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ada7fb65102a4d2c9ab62e8908e9e9f12aed9d76ef44880367bc9308ebe49a0f"},
-    {file = "debugpy-1.8.9-cp310-cp310-win32.whl", hash = "sha256:c36856343cbaa448171cba62a721531e10e7ffb0abff838004701454149bc037"},
-    {file = "debugpy-1.8.9-cp310-cp310-win_amd64.whl", hash = "sha256:17c5e0297678442511cf00a745c9709e928ea4ca263d764e90d233208889a19e"},
-    {file = "debugpy-1.8.9-cp311-cp311-macosx_14_0_universal2.whl", hash = "sha256:b74a49753e21e33e7cf030883a92fa607bddc4ede1aa4145172debc637780040"},
-    {file = "debugpy-1.8.9-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:62d22dacdb0e296966d7d74a7141aaab4bec123fa43d1a35ddcb39bf9fd29d70"},
-    {file = "debugpy-1.8.9-cp311-cp311-win32.whl", hash = "sha256:8138efff315cd09b8dcd14226a21afda4ca582284bf4215126d87342bba1cc66"},
-    {file = "debugpy-1.8.9-cp311-cp311-win_amd64.whl", hash = "sha256:ff54ef77ad9f5c425398efb150239f6fe8e20c53ae2f68367eba7ece1e96226d"},
-    {file = "debugpy-1.8.9-cp312-cp312-macosx_14_0_universal2.whl", hash = "sha256:957363d9a7a6612a37458d9a15e72d03a635047f946e5fceee74b50d52a9c8e2"},
-    {file = "debugpy-1.8.9-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5e565fc54b680292b418bb809f1386f17081d1346dca9a871bf69a8ac4071afe"},
-    {file = "debugpy-1.8.9-cp312-cp312-win32.whl", hash = "sha256:3e59842d6c4569c65ceb3751075ff8d7e6a6ada209ceca6308c9bde932bcef11"},
-    {file = "debugpy-1.8.9-cp312-cp312-win_amd64.whl", hash = "sha256:66eeae42f3137eb428ea3a86d4a55f28da9bd5a4a3d369ba95ecc3a92c1bba53"},
-    {file = "debugpy-1.8.9-cp313-cp313-macosx_14_0_universal2.whl", hash = "sha256:957ecffff80d47cafa9b6545de9e016ae8c9547c98a538ee96ab5947115fb3dd"},
-    {file = "debugpy-1.8.9-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1efbb3ff61487e2c16b3e033bc8595aea578222c08aaf3c4bf0f93fadbd662ee"},
-    {file = "debugpy-1.8.9-cp313-cp313-win32.whl", hash = "sha256:7c4d65d03bee875bcb211c76c1d8f10f600c305dbd734beaed4077e902606fee"},
-    {file = "debugpy-1.8.9-cp313-cp313-win_amd64.whl", hash = "sha256:e46b420dc1bea64e5bbedd678148be512442bc589b0111bd799367cde051e71a"},
-    {file = "debugpy-1.8.9-cp38-cp38-macosx_14_0_x86_64.whl", hash = "sha256:472a3994999fe6c0756945ffa359e9e7e2d690fb55d251639d07208dbc37caea"},
-    {file = "debugpy-1.8.9-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:365e556a4772d7d0d151d7eb0e77ec4db03bcd95f26b67b15742b88cacff88e9"},
-    {file = "debugpy-1.8.9-cp38-cp38-win32.whl", hash = "sha256:54a7e6d3014c408eb37b0b06021366ee985f1539e12fe49ca2ee0d392d9ceca5"},
-    {file = "debugpy-1.8.9-cp38-cp38-win_amd64.whl", hash = "sha256:8e99c0b1cc7bf86d83fb95d5ccdc4ad0586d4432d489d1f54e4055bcc795f693"},
-    {file = "debugpy-1.8.9-cp39-cp39-macosx_14_0_x86_64.whl", hash = "sha256:7e8b079323a56f719977fde9d8115590cb5e7a1cba2fcee0986ef8817116e7c1"},
-    {file = "debugpy-1.8.9-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6953b335b804a41f16a192fa2e7851bdcfd92173cbb2f9f777bb934f49baab65"},
-    {file = "debugpy-1.8.9-cp39-cp39-win32.whl", hash = "sha256:7e646e62d4602bb8956db88b1e72fe63172148c1e25c041e03b103a25f36673c"},
-    {file = "debugpy-1.8.9-cp39-cp39-win_amd64.whl", hash = "sha256:3d9755e77a2d680ce3d2c5394a444cf42be4a592caaf246dbfbdd100ffcf7ae5"},
-    {file = "debugpy-1.8.9-py2.py3-none-any.whl", hash = "sha256:cc37a6c9987ad743d9c3a14fa1b1a14b7e4e6041f9dd0c8abf8895fe7a97b899"},
-    {file = "debugpy-1.8.9.zip", hash = "sha256:1339e14c7d980407248f09824d1b25ff5c5616651689f1e0f0e51bdead3ea13e"},
+    {file = "debugpy-1.8.14-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:93fee753097e85623cab1c0e6a68c76308cd9f13ffdf44127e6fab4fbf024339"},
+    {file = "debugpy-1.8.14-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3d937d93ae4fa51cdc94d3e865f535f185d5f9748efb41d0d49e33bf3365bd79"},
+    {file = "debugpy-1.8.14-cp310-cp310-win32.whl", hash = "sha256:c442f20577b38cc7a9aafecffe1094f78f07fb8423c3dddb384e6b8f49fd2987"},
+    {file = "debugpy-1.8.14-cp310-cp310-win_amd64.whl", hash = "sha256:f117dedda6d969c5c9483e23f573b38f4e39412845c7bc487b6f2648df30fe84"},
+    {file = "debugpy-1.8.14-cp311-cp311-macosx_14_0_universal2.whl", hash = "sha256:1b2ac8c13b2645e0b1eaf30e816404990fbdb168e193322be8f545e8c01644a9"},
+    {file = "debugpy-1.8.14-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cf431c343a99384ac7eab2f763980724834f933a271e90496944195318c619e2"},
+    {file = "debugpy-1.8.14-cp311-cp311-win32.whl", hash = "sha256:c99295c76161ad8d507b413cd33422d7c542889fbb73035889420ac1fad354f2"},
+    {file = "debugpy-1.8.14-cp311-cp311-win_amd64.whl", hash = "sha256:7816acea4a46d7e4e50ad8d09d963a680ecc814ae31cdef3622eb05ccacf7b01"},
+    {file = "debugpy-1.8.14-cp312-cp312-macosx_14_0_universal2.whl", hash = "sha256:8899c17920d089cfa23e6005ad9f22582fd86f144b23acb9feeda59e84405b84"},
+    {file = "debugpy-1.8.14-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6bb5c0dcf80ad5dbc7b7d6eac484e2af34bdacdf81df09b6a3e62792b722826"},
+    {file = "debugpy-1.8.14-cp312-cp312-win32.whl", hash = "sha256:281d44d248a0e1791ad0eafdbbd2912ff0de9eec48022a5bfbc332957487ed3f"},
+    {file = "debugpy-1.8.14-cp312-cp312-win_amd64.whl", hash = "sha256:5aa56ef8538893e4502a7d79047fe39b1dae08d9ae257074c6464a7b290b806f"},
+    {file = "debugpy-1.8.14-cp313-cp313-macosx_14_0_universal2.whl", hash = "sha256:329a15d0660ee09fec6786acdb6e0443d595f64f5d096fc3e3ccf09a4259033f"},
+    {file = "debugpy-1.8.14-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f920c7f9af409d90f5fd26e313e119d908b0dd2952c2393cd3247a462331f15"},
+    {file = "debugpy-1.8.14-cp313-cp313-win32.whl", hash = "sha256:3784ec6e8600c66cbdd4ca2726c72d8ca781e94bce2f396cc606d458146f8f4e"},
+    {file = "debugpy-1.8.14-cp313-cp313-win_amd64.whl", hash = "sha256:684eaf43c95a3ec39a96f1f5195a7ff3d4144e4a18d69bb66beeb1a6de605d6e"},
+    {file = "debugpy-1.8.14-cp38-cp38-macosx_14_0_x86_64.whl", hash = "sha256:d5582bcbe42917bc6bbe5c12db1bffdf21f6bfc28d4554b738bf08d50dc0c8c3"},
+    {file = "debugpy-1.8.14-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5349b7c3735b766a281873fbe32ca9cca343d4cc11ba4a743f84cb854339ff35"},
+    {file = "debugpy-1.8.14-cp38-cp38-win32.whl", hash = "sha256:7118d462fe9724c887d355eef395fae68bc764fd862cdca94e70dcb9ade8a23d"},
+    {file = "debugpy-1.8.14-cp38-cp38-win_amd64.whl", hash = "sha256:d235e4fa78af2de4e5609073972700523e372cf5601742449970110d565ca28c"},
+    {file = "debugpy-1.8.14-cp39-cp39-macosx_14_0_x86_64.whl", hash = "sha256:413512d35ff52c2fb0fd2d65e69f373ffd24f0ecb1fac514c04a668599c5ce7f"},
+    {file = "debugpy-1.8.14-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c9156f7524a0d70b7a7e22b2e311d8ba76a15496fb00730e46dcdeedb9e1eea"},
+    {file = "debugpy-1.8.14-cp39-cp39-win32.whl", hash = "sha256:b44985f97cc3dd9d52c42eb59ee9d7ee0c4e7ecd62bca704891f997de4cef23d"},
+    {file = "debugpy-1.8.14-cp39-cp39-win_amd64.whl", hash = "sha256:b1528cfee6c1b1c698eb10b6b096c598738a8238822d218173d21c3086de8123"},
+    {file = "debugpy-1.8.14-py2.py3-none-any.whl", hash = "sha256:5cd9a579d553b6cb9759a7908a41988ee6280b961f24f63336835d9418216a20"},
+    {file = "debugpy-1.8.14.tar.gz", hash = "sha256:7cd287184318416850aa8b60ac90105837bb1e59531898c07569d197d2ed5322"},
 ]
 
 [[package]]
@@ -364,18 +364,19 @@ zookeeper = ["kazoo (>=2.8.0)"]
 
 [[package]]
 name = "openrelik-worker-common"
-version = "2024.11.27"
+version = "0.13.0"
 description = "Common utilities for OpenRelik workers"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "openrelik_worker_common-2024.11.27-py3-none-any.whl", hash = "sha256:ec8c7b4d8ee40006ebf2ac2f94c38b87a552a930e24128414f8349dceaa19452"},
-    {file = "openrelik_worker_common-2024.11.27.tar.gz", hash = "sha256:e3ea5a89793999d768ee08a4622a483669545afdcd8a144c46270680c0af4d91"},
+    {file = "openrelik_worker_common-0.13.0-py3-none-any.whl", hash = "sha256:5fc374ee7dda9bbeefe22969f01278ebc56c3a45e83ab9c8da32cca7e9b19c6d"},
+    {file = "openrelik_worker_common-0.13.0.tar.gz", hash = "sha256:e534549497732503c1ac4995b8bd345b7a34bfcc0feb7759be7bade4a2c3377d"},
 ]
 
 [package.dependencies]
 debugpy = ">=1.8.6,<2.0.0"
+redis = ">=5.2.1,<6.0.0"
 
 [[package]]
 name = "packaging"
@@ -434,6 +435,24 @@ files = [
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
+name = "pyjwt"
+version = "2.9.0"
+description = "JSON Web Token implementation in Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "PyJWT-2.9.0-py3-none-any.whl", hash = "sha256:3b02fb0f44517787776cf48f2ae25d8e14f300e6d7545a4315cee571a415e850"},
+    {file = "pyjwt-2.9.0.tar.gz", hash = "sha256:7e1e5b56cc735432a7369cbfa0efe50fa113ebecdc04ae6922deba8b84582d0c"},
+]
+
+[package.extras]
+crypto = ["cryptography (>=3.4.0)"]
+dev = ["coverage[toml] (==5.0.4)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=6.0.0,<7.0.0)", "sphinx", "sphinx-rtd-theme", "zope.interface"]
+docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
+tests = ["coverage[toml] (==5.0.4)", "pytest (>=6.0.0,<7.0.0)"]
 
 [[package]]
 name = "pytest"
@@ -513,18 +532,19 @@ six = ">=1.5"
 
 [[package]]
 name = "redis"
-version = "5.2.0"
+version = "5.3.0"
 description = "Python client for Redis database and key-value store"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "redis-5.2.0-py3-none-any.whl", hash = "sha256:ae174f2bb3b1bf2b09d54bf3e51fbc1469cf6c10aa03e21141f51969801a7897"},
-    {file = "redis-5.2.0.tar.gz", hash = "sha256:0b1087665a771b1ff2e003aa5bdd354f15a70c9e25d5a7dbf9c722c16528a7b0"},
+    {file = "redis-5.3.0-py3-none-any.whl", hash = "sha256:f1deeca1ea2ef25c1e4e46b07f4ea1275140526b1feea4c6459c0ec27a10ef83"},
+    {file = "redis-5.3.0.tar.gz", hash = "sha256:8d69d2dde11a12dc85d0dbf5c45577a5af048e2456f7077d87ad35c1c81c310e"},
 ]
 
 [package.dependencies]
 async-timeout = {version = ">=4.0.3", markers = "python_full_version < \"3.11.3\""}
+PyJWT = ">=2.9.0,<2.10.0"
 
 [package.extras]
 hiredis = ["hiredis (>=3.0.0)"]
@@ -637,4 +657,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "5eff28362602b95a9c3bd9eaf54d6b49396c54ed4e1d0f4787d136303c27d200"
+content-hash = "61078bba42b81b050cbb0cea18e1ff7a8e88a40304d4797a0e23c255092314d5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openrelik-worker-yara"
-version = "2025.05.30"
+version = "0.1.0"
 description = "Scan a local directory using Fraken-X"
 authors = ["Thomas Chopitea <tomchop@gmail.com>", "Fry <fryx0r@gmail.com>"]
 readme = "README.md"
@@ -9,7 +9,7 @@ package-mode = false
 [tool.poetry.dependencies]
 python = "^3.10"
 celery = {extras = ["redis"], version = "^5.4.0"}
-openrelik-worker-common = "^2024.11.27"
+openrelik-worker-common = "^0.13.0"
 
 [tool.poetry.group.test.dependencies]
 pytest = "*"

--- a/src/app.py
+++ b/src/app.py
@@ -17,7 +17,7 @@ import os
 import redis
 from celery.app import Celery
 
-from openrelik_worker_common.debug_utils import start_debugger
+from .openrelik_worker_common.debug_utils import start_debugger
 
 if os.getenv("OPENRELIK_PYDEBUG") == "1":
     start_debugger()

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -161,7 +161,7 @@ def command(
                     logger.debug("Reading rule from %s", rule_file)
                     all_patterns += rf.read()
                     total_rules_read += 1
-    logger.info(f"Read {total_rules_read} rules")
+    logger.info(f"Read {total_rules_read} rule files.")
 
     if manual_yara:
         logger.info("Manual rules provided, added manual Yara rules")

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -49,6 +49,14 @@ TASK_METADATA = {
             "type": "textarea",
             "required": False,
         },
+        {
+            "name": "mount_disk_images",
+            "label": "Mount disk images",
+            "description": "If checked, the worker will try to mount disk images and scan the files inside the disk image.",
+            "type": "checkbox",
+            "required": True,
+            "default_value": False,
+        },
     ],
 }
 
@@ -131,6 +139,7 @@ def command(
     all_patterns = ""
     global_yara = task_config.get("Global Yara rules", "")
     manual_yara = task_config.get("Manual Yara rules", "")
+    mount_disk_images = task_config.get("mount_disk_images", False)
 
     if not global_yara and not manual_yara:
         raise RuntimeError(
@@ -192,7 +201,7 @@ def command(
 
             input_file_path = input_file.get("path")
             # Check if disk image, mount and add mountpoints to scan
-            if is_disk_image(input_file):
+            if mount_disk_images and is_disk_image(input_file):
                 bd = BlockDevice(input_file_path, min_partition_size=1)
                 bd.setup()
                 mountpoints = bd.mount()

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -19,9 +19,10 @@ import os
 import subprocess
 from dataclasses import dataclass
 
-from openrelik_worker_common.file_utils import create_output_file
-from openrelik_worker_common.reporting import MarkdownTable, Priority, Report
-from openrelik_worker_common.task_utils import create_task_result, get_input_files
+from .openrelik_worker_common.file_utils import create_output_file, is_disk_image
+from .openrelik_worker_common.mount_utils import BlockDevice
+from .openrelik_worker_common.reporting import MarkdownTable, Priority, Report
+from .openrelik_worker_common.task_utils import create_task_result, get_input_files
 
 from .app import celery
 
@@ -52,12 +53,14 @@ TASK_METADATA = {
     ],
 }
 
+
 def safe_list_get(l, index, default):
     """Small helper function to safely get an item from a list."""
     try:
         return l[index]
     except IndexError:
         return default
+
 
 @dataclass
 class YaraMatch:
@@ -82,14 +85,21 @@ def generate_report_from_matches(matches: list[YaraMatch]) -> Report:
     """
     report = Report("Yara scan report")
     matches_section = report.add_section()
-    matches_section.add_paragraph(
-        "List of Yara matches found in the scanned files."
-    )
+    matches_section.add_paragraph("List of Yara matches found in the scanned files.")
     if matches:
         report.priority = Priority.CRITICAL
     match_table = MarkdownTable(["filepath", "hash", "rule", "desc", "ref", "score"])
     for match in matches:
-        match_table.add_row([match.filepath, match.hash, match.rule, match.desc, match.ref, str(match.score)])
+        match_table.add_row(
+            [
+                match.filepath,
+                match.hash,
+                match.rule,
+                match.desc,
+                match.ref,
+                str(match.score),
+            ]
+        )
 
     matches_section.add_table(match_table)
 
@@ -124,18 +134,26 @@ def command(
     manual_yara = task_config.get("Manual Yara rules", "")
 
     if not global_yara and not manual_yara:
-        raise RuntimeError("At least one of Global and/or Manual Yara rules must be provided")
+        raise RuntimeError(
+            "At least one of Global and/or Manual Yara rules must be provided"
+        )
 
-    for rule_path in global_yara.split('\n'):
+    total_rules_read = 0
+    for rule_path in global_yara.split("\n"):
         if os.path.isfile(rule_path):
             with open(rule_path, encoding="utf-8") as rf:
-                logger.info("Reading rule from %s", rule_path)
+                logger.debug("Reading rule from %s", rule_path)
                 all_patterns += rf.read()
+                total_rules_read += 1
         if os.path.isdir(rule_path):
-            for rule_file in glob.glob(os.path.join(rule_path, '**/*.yar*'), recursive=True):
+            for rule_file in glob.glob(
+                os.path.join(rule_path, "**/*.yar*"), recursive=True
+            ):
                 with open(rule_file, encoding="utf-8") as rf:
-                    logger.info("Reading rule from %s", rule_file)
+                    logger.debug("Reading rule from %s", rule_file)
                     all_patterns += rf.read()
+                    total_rules_read += 1
+    logger.info(f"Read {total_rules_read} rules")
 
     if manual_yara:
         logger.info("Manual rules provided, added manual Yara rules")
@@ -158,24 +176,55 @@ def command(
 
     input_files_map = {}
     for input_file in input_files:
-        input_files_map[input_file.get(
-            "path", input_file.get("uuid", "UNKNOWN FILE"))] = input_file.get(
-                "display_name", "UNKNOWN FILE NAME")
+        input_files_map[
+            input_file.get("path", input_file.get("uuid", "UNKNOWN FILE"))
+        ] = input_file.get("display_name", "UNKNOWN FILE NAME")
 
-    folders_and_files = []
-    for input_file in input_files:
-        if 'path' not in input_file:
-            logger.warning("Skipping file %s as it does not have an path", input_file)
-            continue
-        folders_and_files.append('--folder')
-        folders_and_files.append(input_file.get('path'))
+    try:
+        folders_and_files = []
+        bd = None
+        disks_mounted = []
+        for input_file in input_files:
+            if "path" not in input_file:
+                logger.warning(
+                    "Skipping file %s as it does not have an path", input_file
+                )
+                continue
 
-    cmd = ['fraken'] + folders_and_files + [f'{all_yara.path}']
-    with open(fraken_output.path, 'w+', encoding="utf-8") as log:
-        process = subprocess.Popen(cmd, stdout=log)
-        process.wait()
+            input_file_path = input_file.get("path")
+            # Check if disk image, mount and add mountpoints to scan
+            if is_disk_image(input_file):
+                bd = BlockDevice(input_file_path, min_partition_size=1)
+                bd.setup()
+                mountpoints = bd.mount()
+                disks_mounted.append(bd)
 
-    with open(fraken_output.path, 'r', encoding="utf-8") as json_file:
+                if not mountpoints:
+                    logger.info(
+                        "No mountpoints returned for input file %s",
+                        input_file.get("display_name"),
+                    )
+                for mountpoint in mountpoints:
+                    folders_and_files.append("--folder")
+                    folders_and_files.append(mountpoint)
+            else:
+                folders_and_files.append("--folder")
+                folders_and_files.append(input_file_path)
+
+        cmd = ["fraken"] + folders_and_files + [f"{all_yara.path}"]
+        logger.debug(f"fraken-x command: {cmd}")
+        with open(fraken_output.path, "w+", encoding="utf-8") as log:
+            process = subprocess.Popen(cmd, stdout=log)
+            process.wait()
+    except RuntimeError as e:
+        logger.error("Error encountered: %s", str(e))
+    finally:
+        for blockdevice in disks_mounted:
+            if blockdevice:
+                logger.debug(f"Unmounting image {blockdevice.image_path}")
+                blockdevice.umount()
+
+    with open(fraken_output.path, "r", encoding="utf-8") as json_file:
         matches_list_list = list(json_file)
 
         for matches_list in matches_list_list:
@@ -184,12 +233,14 @@ def command(
             for match in matches:
                 all_matches.append(
                     YaraMatch(
-                        filepath=input_files_map.get(match['ImagePath'], match['ImagePath']),
-                        hash=match['SHA256'],
-                        rule=match['Signature'],
-                        desc=match['Description'],
-                        ref=match['Reference'],
-                        score=match['Score'],
+                        filepath=input_files_map.get(
+                            match["ImagePath"], match["ImagePath"]
+                        ),
+                        hash=match["SHA256"],
+                        rule=match["Signature"],
+                        desc=match["Description"],
+                        ref=match["Reference"],
+                        score=match["Score"],
                     )
                 )
 

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -49,7 +49,6 @@ TASK_METADATA = {
             "type": "textarea",
             "required": False,
         },
-        # TODO(fryy): Option to mount input file/s ?
     ],
 }
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,13 @@
+"""Tests tasks."""
+
+# Note: Use pytest for writing tests!
+import pytest
+
+# from src.tasks import command
+
+
+def test_task_command():
+    """Test command task."""
+
+    ret = "some dummy return value"
+    assert isinstance(ret, str)


### PR DESCRIPTION
This PR:
* adds mount functionality so the yara scanner can scan disk images.
* splits the fraken-x build into its own container for speed, container size and standalone usage.

Extra:
* updated README
* updated version numbering scheme
* updated openrelik_worker_common lib version
* adds devcontainer configuration (easy to poetry lock and run tests)

Fix #3

**Note**: This needs a new release of the openrelik-worker-common lib with the is_disk_image() method.